### PR TITLE
Allow using callables as a value for fields

### DIFF
--- a/tbs_class.php
+++ b/tbs_class.php
@@ -3999,6 +3999,8 @@ static function meth_Misc_ToStr($Value) {
 		} elseif (is_a($Value, 'DateTime')) {
 			// ISO date-time format
 			return $Value->format('c');
+		} elseif(is_callable($Value)) { 
+			return $Value = (string)$Value();
 		}
 	}
 	return @(string)$Value; // (string) is faster than strval() and settype()


### PR DESCRIPTION
This allows the use of a callable as a value for merged fields. For example in your PHP code:

```
$TBS->MergeField('callable_field', fn() => Carbon::now()->addMonths(12)->toDateString());
```

Then in your HTML template you can use merge field like `[callable_field]`, which would resolve the callable to a string.

This is useful when you have many "magic fields" that require evaluating a callable. In my case, I have "magic links" that can be generated and included in the template (e.g. one time use login links). I don't want to process those methods every time I merge a doc, rather, this dynamically calls the method just in time.

