### PR TITLE
class clsTbsDataSource updated to have a public var $ByPage;

### DIFF
--- a/tbs_class.php
+++ b/tbs_class.php
@@ -154,6 +154,7 @@ public $SubType = 0;
 public $SrcId = false;
 public $Query = '';
 public $RecSet = false;
+public $ByPage; 		// Used by ByPage plugin
 public $RecNumInit = 0; // Used by ByPage plugin
 public $RecSaving = false;
 public $RecSaved = false;


### PR DESCRIPTION
This avoids depricated warnings on PHP 8.2+