### PR TITLE
Fix: use extension Intl instead of strftime() for date format '(locale)'

### DIFF
--- a/tbs_class.php
+++ b/tbs_class.php
@@ -4155,14 +4155,61 @@ function meth_Misc_DateFormat(&$Value, $Frm) {
 		}
 	}
 	
-	if ($Frm['loc'] || isset($PrmLst['locale'])) {
-		$x = strftime($Frm['str_loc'],$Value);
+	if ($Frm['loc']) {
+		$x = self::f_Misc_DateFormatLoc($Value,$Frm['str_us']);
 		$this->meth_Conv_Str($x,false); // may have accent
 		return $x;
 	} else {
 		return date($Frm['str_us'],$Value);
 	}
-	
+
+}
+
+/**
+ * Format a timestamp using the locale set with setlocale() for category LC_TIME, that is format '(locale)'.
+ * Extension Intl is used instead of strftime() which is deprecated since PHP 8.1 and deleted since PHP 9.0.
+ * @param  int    $Value  The timestamp.
+ * @param  string $FrmPHP The format in PHP date() syntax.
+ * @return string The formated date.
+ */
+static function f_Misc_DateFormatLoc($Value, $FrmPHP) {
+	if (!class_exists('IntlDateFormatter')) return date($FrmPHP,$Value); // no localization available
+	$loc = (string) setlocale(LC_TIME,'0'); // '0' reads the current locale without changing it
+	$loc = substr($loc,0,strcspn($loc,'.@')); // 'de_DE.UTF-8@euro' => 'de_DE'
+	if (($loc==='C') || ($loc==='POSIX')) $loc = 'en_US_POSIX'; // default locale of PHP, it gives English names
+	$f = new IntlDateFormatter($loc, 0, 0, date_default_timezone_get(), IntlDateFormatter::GREGORIAN, self::f_Misc_DateToIcu($FrmPHP));
+	return $f->format((int) $Value);
+}
+
+/**
+ * Convert a date format from the PHP date() syntax to the ICU syntax used by extension Intl.
+ * @param  string $FrmPHP The format in PHP date() syntax. Example: 'l j \d\e F Y'
+ * @return string The format in ICU syntax.              Example: "EEEE d 'de' MMMM yyyy"
+ */
+static function f_Misc_DateToIcu($FrmPHP) {
+	$map = array('H'=>'HH', 'G'=>'H', 'h'=>'hh', 'g'=>'h', 'a'=>'a', 'A'=>'a', 'i'=>'mm', 's'=>'ss', 'S'=>'',
+		'Y'=>'yyyy', 'y'=>'yy', 'F'=>'MMMM', 'M'=>'MMM', 'm'=>'MM', 'n'=>'M',
+		'l'=>'EEEE', 'D'=>'EEE', 'w'=>'e', 'd'=>'dd', 'j'=>'d');
+	$icu = '';
+	$txt = ''; // literal chars waiting to be quoted
+	$max = strlen($FrmPHP);
+	for ($i=0; $i<$max; $i++) {
+		$c = $FrmPHP[$i];
+		if ($c==='\\') {
+			$i++;
+			$txt .= substr($FrmPHP,$i,1); // protected char
+		} elseif (isset($map[$c])) {
+			if ($txt!=='') { // literal chars must be quoted because letters are reserved by ICU
+				$icu .= "'".str_replace("'","''",$txt)."'";
+				$txt = '';
+			}
+			$icu .= $map[$c];
+		} else {
+			$txt .= $c;
+		}
+	}
+	if ($txt!=='') $icu .= "'".str_replace("'","''",$txt)."'";
+	return $icu;
 }
 
 /**

--- a/testunit/testcase/FrmTestCase.php
+++ b/testunit/testcase/FrmTestCase.php
@@ -119,13 +119,23 @@ class FrmTestCase extends TBSUnitTestCase {
 		$this->assertEqualMergeFieldStrings("{[a;frm=r]}", array('a'=>$d),  "{9}", "test hour (one digit)");
 		$this->assertEqualMergeFieldStrings("{[a;frm=hm]}", array('a'=>$d),  "{09}", "test hour (deprecated)"); // hm is like rr, it's deprecated since TBS 3.2.0
 
-		// locale
-		/* no configuration file on my computer :(
-		$currLocale = setlocale(LC_TIME, null); // save current Locale
-		setlocale(LC_TIME, 'fr_FR'); // change current Locale
-		$this->assertEqualMergeFieldStrings("{[a;frm=m mm mmm mmmm(locale)]}", array('a'=>$d),   "{11 11 Nov Novembre}", "test month formats (month>=10)");
+		// locale : conversion of the format into the ICU syntax used by extension Intl
+		if (method_exists('clsTinyButStrong', 'f_Misc_DateToIcu')) {
+			$this->assertEqual(clsTinyButStrong::f_Misc_DateToIcu('Y-m-d H:i:s'), "yyyy'-'MM'-'dd' 'HH':'mm':'ss", "test ICU conversion of numeric items");
+			$this->assertEqual(clsTinyButStrong::f_Misc_DateToIcu('l j \\d\\e F Y'), "EEEE' 'd' de 'MMMM' 'yyyy", "test ICU conversion with a protected text part");
+			$this->assertEqual(clsTinyButStrong::f_Misc_DateToIcu("\\l'\\a\\n\\s Y"), "'l''ans 'yyyy", "test ICU conversion with an apostrophe in the text part");
+		}
+
+		// locale : localized date. The test is skipped if the locale is not installed on the system.
+		$currLocale = setlocale(LC_TIME, '0'); // save current Locale
+		if (setlocale(LC_TIME, 'fr_FR.UTF-8', 'fr_FR', 'fr') !== false) {
+			if (class_exists('IntlDateFormatter')) {
+				$this->assertEqualMergeFieldStrings("{[a;frm=m mm mmmm(locale)]}", array('a'=>$d), "{11 11 novembre}", "test month formats with locale");
+				$this->assertEqualMergeFieldStrings("{[a;frm=dddd(locale)]}", array('a'=>$d), "{vendredi}", "test day name with locale");
+			}
+			$this->assertEqualMergeFieldStrings("{[a;frm=(locale)yyyy-mm-dd hh:nn:ss]}", array('a'=>$d), "{2001-11-30 21:46:33}", "test date with locale but no localized item");
+		}
 		setlocale(LC_TIME, $currLocale); // restore current Locale
-		*/
 
 		// string values. TBS try to convert strings into timestamps using the PHP function strtotime()
 		$this->assertEqualMergeFieldStrings("{[a;frm=yyyy-mm-dd hh:nn:ss]}", array('a'=>'2001-12-05'),  "{2001-12-05 00:00:00}", "test string values (ISO without hour)");


### PR DESCRIPTION
### Problem

The date format `(locale)` is merged with `strftime()`, which is **deprecated since PHP 8.1** and **deleted since PHP 9.0**. So the format currently raises a deprecation notice, and it is going to raise a fatal error.

```php
$x = strftime($Frm['str_loc'], $Value); // meth_Misc_DateFormat()
```

This is the only way to get localized month and day names with TBS, since `mmm`/`mmmm` are merged with `date()` which always gives English names.

### Fix

The format is converted into the ICU syntax and merged with `IntlDateFormatter` (extension Intl, bundled with PHP and enabled by default since PHP 8.0):

* the locale is the one set with `setlocale()` for category `LC_TIME`, like `strftime()` did, so existing applications do not have to be changed,
* locales `C` and `POSIX` are mapped to `en_US_POSIX` in order to keep English names when no locale is set,
* if extension Intl is not available, then the format falls back on `date()` which gives English names, like a non `(locale)` format.

The format parser is not changed: the ICU format is deduced from the PHP format (`str_us`) which is already prepared by `f_Misc_CheckArgFormat()`.

Example with `setlocale(LC_TIME, 'de_DE.UTF-8')`:

```
[a;frm=(locale)dddd", "d". "mmmm yyyy]   =>  Freitag, 30. November 2001
[a;frm=dddd", "d". "mmmm yyyy]           =>  Friday, 30. November 2001   (unchanged)
```

### Notes

* Item `xx` (ordinal suffix) has no ICU equivalent, so it is ignored in a `(locale)` format. This is the same behavior as before since `%` had no equivalent for `strftime()` either.
* Abbreviated names follow the ICU conventions of the locale (`nov.` for `fr_FR` instead of `nov`).

### Unit tests

Unit tests are added in `FrmTestCase` (the commented locale test is replaced):

* the conversion into the ICU syntax is tested directly, so it runs on any system,
* the localized merges are skipped when the system locale (`fr_FR`) or extension Intl is missing.

Result on PHP 8.3: 398 passes, 0 failures (392 passes before the patch).
